### PR TITLE
[#179570][#417139] Fix input maxlength and min/max in IE

### DIFF
--- a/src/form/editors/NumberEditorView.js
+++ b/src/form/editors/NumberEditorView.js
@@ -102,7 +102,8 @@ export default formRepository.editors.Number = BaseEditorView.extend({
             'click @ui.clearButton': '__onClearClickHandler',
             'dblclick @ui.clearButton': '__onClearDblclick',
             'keyup @ui.input': '__keyup',
-            'change @ui.input': '__onChange'
+            'change @ui.input': '__onChange',
+            'blur @ui.input': '__onBlur'
         };
         if (!this.options.hideClearButton) {
             events.mouseenter = '__onMouseenter';
@@ -129,15 +130,19 @@ export default formRepository.editors.Number = BaseEditorView.extend({
     },
 
     __keyup(event) {
-        const value = event.target.value;
+        let value = event.target.value;
+        const max = event.target.max;
+        const min = event.target.min;
         if (this.__isTypeInFractionPart(value) && this.__isTypeInTheEnd(value) && value.slice(-1) === '0') {
             return;
         }
 
         const parsed = this.__parse(value);
-        if (parsed === 0 && value[0] === '-') {
+        if ((parsed === 0 || parsed === null) && value[0] === '-') {
             return;
         }
+
+        value = Number(min) < 0 ? this.__checkMaxMinValue(value, max, min) : this.__checkMaxMinValue(value, max);
 
         this.__value(value, true, this.isChangeModeKeydown || event.keyCode === keyCode.ENTER, false);
     },
@@ -159,6 +164,12 @@ export default formRepository.editors.Number = BaseEditorView.extend({
         const min = input[0].getAttribute('min');
         const value = this.__checkMaxMinValue(input.val(), max, min);
         this.__value(value, false, true, false);
+    },
+
+    __onBlur() {
+        if (Core.services.MobileService.isIE) {
+            this.__onChange();
+        }
     },
 
     __checkMaxMinValue(value, max, min) {


### PR DESCRIPTION
В __onChange логика сравнения и подстановки значения такая же, как в __keyup, но в IE значения не всегда менялись при выполнении __onChange (при этом __keyup всегда срабатывает в IE).
Я пробовал изменить получение значений в __onChange с геттеров и jQuery на прямое обращение к свойствам. Не сработало.
Еще пробовал по аналогии с CodemirrorView дополнительно тригерить событие change при blur:
```
 __onBlur() {
    this.__change();
},

__change() {
    this.trigger('change', this);
},
```
Тоже не сработало.