### PR TITLE
[#567867] Fix render addNewButton in dropdown panel

### DIFF
--- a/src/dropdown/views/DropdownView.ts
+++ b/src/dropdown/views/DropdownView.ts
@@ -169,6 +169,7 @@ export default class DropdownView {
             return;
         }
         this.panelEl.style.height = ''; //resetting custom height
+        this.panelView.ui?.addNewButton?.hide();
 
         const viewportHeight = window.innerHeight;
         const dropDownRoot = this.button.$el.closest('.js-dropdown__root')[0];
@@ -267,6 +268,7 @@ export default class DropdownView {
             this.panelEl.classList.remove(classes.DROPDOWN_DOWN);
         }
 
+        this.panelView.ui?.addNewButton?.show();
         offsetHeight = this.panelEl.offsetHeight;
 
         // panel positioning


### PR DESCRIPTION
Суть баги в том, что кнопка прыгает сверху вниз, т.е не сразу подставляется нужный класс. Сначала рендерится и аттачится выпадашка и только потом срабатывает __adjustPosition, который подставляет нужные классы для рендера кнопки внизу. Выполнять __adjustPosition до аттача выпадашки нельзя, так как это ломает выполнение этого метода в других местах. После уже не имеет смысла, т.к проблему не решает. Привязка __adjustPosition к каким-либо ивентам (вкл. жизненного цикла вью) либо не фиксит, либо ломает работающий функционал.
Я сделал так, что в случае, если у панели выпадашки есть addNewButton, то она скрывается до тех пор, пока не выполнятся необходимые операции с домом. Так уже ничего не прыгает.
Мой полет фантазии закончился на этом решении, поэтому буду рад, если кто-нибудь подскажет что-то получше)