### PR TITLE
[#887190] Fix space before a required attribute in form editor

### DIFF
--- a/resources/styles/applyStyles.css
+++ b/resources/styles/applyStyles.css
@@ -328,7 +328,6 @@ input::placeholder {
 }
 
 .form-label_required {
-    padding-left: 10px;
     position: relative;
 }
 


### PR DESCRIPTION
![2022-01-13_16-28-57](https://user-images.githubusercontent.com/39082224/149339232-2429a0fe-d424-4397-b0c7-1d13f5a4f103.png)
