### PR TITLE
[#1056160] Smallfix - editor overlaps table header

### DIFF
--- a/resources/styles/list.css
+++ b/resources/styles/list.css
@@ -224,7 +224,7 @@
     height: 35px;
     position: sticky;
     top: 0;
-    z-index: 2;
+    z-index: 10;
     background-clip: padding-box;
     max-width: 0; /* hack to set width less than cells content */
     line-height: 30px;


### PR DESCRIPTION
![2022-02-15_15-24-02](https://user-images.githubusercontent.com/39082224/154063776-7ee3c0f4-7766-4a77-86f9-ec6957431679.png)
